### PR TITLE
Fix Discord message job having wrong argument

### DIFF
--- a/app/jobs/discord-message.js
+++ b/app/jobs/discord-message.js
@@ -2,7 +2,7 @@
 const axios = require('axios')
 
 class DiscordMessageJob {
-  async run (type, content) {
+  async run (content) {
     await axios({
       method: 'post',
       url: process.env.DISCORD_WEBHOOK_URL,


### PR DESCRIPTION
The DiscordMessageJob still expected the type argument, this PR fixes that.