### PR TITLE
feat(TrelloService): support missing action types

### DIFF
--- a/src/services/trello.ts
+++ b/src/services/trello.ts
@@ -67,7 +67,7 @@ export default class TrelloService {
           return {
             title: `${cardSlug} Card ${card.closed as boolean ? '' : 'un'}archived`
           }
-        } else if (typeof oldCard.desc !== 'undefined') {
+        } else if (typeof oldCard.desc !== 'undefined' && oldCard.desc === '') {
           return {
             title: `${cardSlug} Card description ${card.desc as string === '' ? 'deleted' : 'updated'}`,
             description: card.desc !== '' ? card.desc : undefined

--- a/src/services/trello.ts
+++ b/src/services/trello.ts
@@ -50,6 +50,9 @@ export default class TrelloService {
     action: any
   ): Promise<APIEmbed | { embed: APIEmbed, files: Record<string, Buffer> } | undefined> {
     const card = action.data.card
+    if (typeof card === 'undefined') {
+      return
+    }
     const cardSlug = `[${action.data.board.name}: ${card.name}]`
     switch (action.type) {
       case 'createCard': {

--- a/src/services/trello.ts
+++ b/src/services/trello.ts
@@ -148,6 +148,13 @@ export default class TrelloService {
         }
       }
 
+      case 'commentCard': {
+        return {
+          title: `${cardSlug} Comment added`,
+          description: action.data.text
+        }
+      }
+
       default: {
         return undefined
       }

--- a/src/services/trello.ts
+++ b/src/services/trello.ts
@@ -77,6 +77,11 @@ export default class TrelloService {
             title: `[${action.data.board.name}: ${oldCard.name}] Card renamed`,
             description: action.data.card.name
           }
+        } else if (typeof oldCard.idList !== 'undefined') {
+          return {
+            title: `${cardSlug} Card moved`,
+            description: `${action.data.listBefore.name} → ${action.data.listAfter.name}`
+          }
         }
         return
       }


### PR DESCRIPTION
This PR adds output for the `commentCard` action type and when a card is moved to another list. It also check when a card description is updated that it was empty before, so small card description fixes shouldn't have an output anymore.

Lastly it fixes a bug where on card unrelated actions the service method would fail because card is undefined.

Resolves #6 